### PR TITLE
Fix firmware links

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The REVIUNG33 is 33-key ortholinear keyboard.
 
 The REVIUNG53 is 53-key keyboard.  
 
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung53)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung53)  
 
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The REVIUNG41 is 41-key column staggered keyboard.  
 
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung41)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung41)  
 [Build guide](https://reviung.com/build-guide/391/)  
   
 <br>
@@ -16,7 +16,7 @@ The REVIUNG39 is 39-key column staggered keyboard.
 
 Soldering is divided into through-hole mounting version and surface mounting (SMD) version so that the soldering difficulty can be selected.  
 
-- EVIUNG39 Mk-II and REVIUNG39 is regular version (SMD)  
+- REVIUNG39 Mk-II and REVIUNG39 is regular version (SMD)  
 - REVIUNG39S is simple version (through-hole)  
 
 [REVIUNG39 Mk-II ](https://github.com/gtips/reviung/tree/master/reviung39Mk-II)   
@@ -30,7 +30,7 @@ Soldering is divided into through-hole mounting version and surface mounting (SM
 <br>
 
 [REVIUNG39 Build guide](https://reviung.com/build-guide/108/)  
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung39)
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung39)
   
 <br>
 <br>
@@ -45,7 +45,7 @@ The REVIUNG34 is 34-key (or33-key) column staggered keyboard.
 <br>
 
 [REVIUNG34 Build guide](https://reviung.com/build-guide/724/)  
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung34)
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung34)
   
 <br>
 <br>
@@ -59,7 +59,7 @@ The REVIUNG5 is 5-key (or 4-key + Rotary Encoder) macropad.
 <br>
 
 [REVIUNG5 Build guide](https://reviung.com/build-guide/)  
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung5)
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung5)
   
 <br>
 <br>
@@ -78,7 +78,7 @@ Use a LAN cable to connect the left and right keyboards.
 [REVIUNG34 SPLIT](https://github.com/gtips/reviung/tree/master/reviung34split)  
 [![REVIUNG34 SPLIT](https://github.com/gtips/reviung/blob/master/reviung34split/image/REVIUNG34-1.jpg)](https://github.com/gtips/reviung/tree/master/reviung34split)  
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung34)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung34)  
 [REVIUNG34 SPLIT Build guide](https://reviung.com/build-guide/278/)  
 
 <br>
@@ -89,7 +89,7 @@ Use a LAN cable to connect the left and right keyboards.
 
 The REVIUNG33 is 33-key ortholinear keyboard.  
 
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung33)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung33)  
 
 <br>
 <br>
@@ -109,7 +109,7 @@ The REVIUNG53 is 53-key keyboard.
 
 Standard ANSI 60% keyboard. And compatible with MX and ALPS.  
 
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung61)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung61)  
 
 <br>
 <br>

--- a/reviung33/README.md
+++ b/reviung33/README.md
@@ -44,7 +44,7 @@ The REVIUNG33 is 33-key ortholinear keyboard.
 | 32 | Keycap (1U) | 
 | 1 | Keycap (6.25U) |   
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung33)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung33)  
 [Build guide](https://reviung.com/)  
   
 ![REVIUNG33](https://github.com/gtips/reviung/blob/master/reviung33/image/reviung33-02.jpg)  

--- a/reviung34/README.md
+++ b/reviung34/README.md
@@ -35,7 +35,7 @@ The REVIUNG34 is 34-key (or 33-key) column staggered keyboard.
 | 0 (or 1) | MX compatible Keycap (2U) |  |
 | 1 | MicroUSB cable |  |
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung34)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung34)  
 [Build guide](https://reviung.com/build-guide/)  
   
 ![REVIUNG34](https://github.com/gtips/reviung/blob/master/reviung34/image/reviung34-03.jpg)  

--- a/reviung34split/README.md
+++ b/reviung34split/README.md
@@ -4,7 +4,7 @@
 The REVIUNG34 SPLIT is 34-key split ortholinear keyboard.  
 Use a LAN cable to connect the left and right keyboards.  
 
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung34)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung34)  
 [Build guide](https://reviung.com/build-guide/278/)  
 
 #### Parts list  

--- a/reviung34split_Mk-II/README.md
+++ b/reviung34split_Mk-II/README.md
@@ -28,7 +28,7 @@ Choose "1u key x3" or "1u and 2u key" for the left thumb key.
 | 1 | MicroUSB cable |  |
 | 1 | Ethernet cable |  |
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung34)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung34)  
 [Build guide](https://reviung.com/build-guide/656/)  
   
 ![REVIUNG34 Mk-II](https://github.com/gtips/reviung/blob/master/reviung34split_Mk-II/image/reviung34mkII-02.jpg)  

--- a/reviung39/README.md
+++ b/reviung39/README.md
@@ -30,7 +30,7 @@ Keycap (2.25U or 2U) --- 1
 Keycap (1.25U or 1U) --- 2  
 MicroUSB cable --- 1  
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung39)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung39)  
 [Build guide](https://reviung.com/build-guide/108/)  
   
 ![REVIUNG39](https://github.com/gtips/reviung/blob/master/reviung39/image/REVIUNG39-2.jpg)  

--- a/reviung39_Mk-II/README.md
+++ b/reviung39_Mk-II/README.md
@@ -34,7 +34,7 @@ The REVIUNG39 Mk-II is 39-key column staggered keyboard.
 | 2 | Keycap (1.25U or 1U) |  |
 | 1 | MicroUSB cable |  |
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung39)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung39)  
 [Build guide](https://reviung.com/build-guide/583/)  
   
 ![REVIUNG39 Mk-II](https://github.com/gtips/reviung/blob/master/reviung39_Mk-II/image/reviung39MkII-0.jpg)  

--- a/reviung39s/README.md
+++ b/reviung39s/README.md
@@ -30,7 +30,7 @@ MicroUSB cable --- 1
 option  
 LED Strip(tape) for Underglow (with 6 WS2812B)  
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung39)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung39)  
 [Build guide](https://reviung.com/build-guide/112/)  
   
 ![REVIUNG39](https://github.com/gtips/reviung/blob/master/reviung39s/image/REVIUNG39s-5.jpg)  

--- a/reviung41/README.md
+++ b/reviung41/README.md
@@ -32,7 +32,7 @@ Keycap (2.25U or 2U) --- 1
 Keycap (1.25U or 1U) --- 4  
 MicroUSB cable --- 1  
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung41)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung41)  
 [Build guide](https://reviung.com/build-guide/391/)  
   
 ![REVIUNG41](https://github.com/gtips/reviung/blob/master/reviung41/image/REVIUNG41B-2.jpg)  

--- a/reviung5/README.md
+++ b/reviung5/README.md
@@ -28,7 +28,7 @@ The REVIUNG5 is 5-key (or 4-key + Rotary Encoder) macropad.
 | 1 (or 0) | Rotary Encoder | Alps EC12 series compatible | 
 | 1 | MicroUSB cable |  |
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung5)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung5)  
 [Build guide](https://reviung.com/build-guide/)  
   
 ![REVIUNG5](https://github.com/gtips/reviung/blob/master/reviung5/image/reviung5-2.jpg)  

--- a/reviung53/README.md
+++ b/reviung53/README.md
@@ -34,7 +34,7 @@ Middle acrylic plate (bottom) --- 1
 Silicon sheet --- 1 sheet  
 M2 screw 12mm --- 10 pcs  
   
-[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung53)  
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung53)  
 [Build guide](https://reviung.com/build-guide/)  
   
 ![REVIUNG53](https://github.com/gtips/reviung/blob/master/reviung53/image/reviung53-02.jpg)  

--- a/reviung61/README.md
+++ b/reviung61/README.md
@@ -27,3 +27,4 @@ Standard ANSI 60% keyboard. And compatible with MX and ALPS.
 | 1 | SW57 | MX or ALPS Switche | 6.25U |
 
   
+[Firmware](https://github.com/qmk/qmk_firmware/tree/master/keyboards/reviung/reviung61)  


### PR DESCRIPTION
QMK reorganized their repository slightly and moved all reviung boards into a reviung directory. As such, all firmware links were hitting a 404. This update serves to fix those broken links. 